### PR TITLE
use consistent hashing to get the subdomain

### DIFF
--- a/lib/gravatarify.rb
+++ b/lib/gravatarify.rb
@@ -1,4 +1,5 @@
 require 'gravatarify/version'
+require 'zlib'
 
 # Provides support for adding gravatar images in ruby (and rails)
 # applications.
@@ -51,7 +52,7 @@ module Gravatarify
     def subdomain(str) #:nodoc:
       @subdomains ||= []
       unless @subdomains.empty?
-        subdomain = @subdomains[str.hash % @subdomains.size]
+        subdomain = @subdomains[Zlib.crc32(str) % @subdomains.size]
         subdomain + "." if subdomain
       end
     end


### PR DESCRIPTION
String#hash is based on the ruby object, and changes per process.  The zlib crc should be consistent given the same string.
